### PR TITLE
Change to wrong password test

### DIFF
--- a/client/src/main/java/io/cloudsoft/winrm4j/client/WinRmClient.java
+++ b/client/src/main/java/io/cloudsoft/winrm4j/client/WinRmClient.java
@@ -218,11 +218,11 @@ public class WinRmClient {
 
         /**
          * @param retriesConnectionFailures How many times to retry the command before giving up in case of failure (exception).
-         *        Default is 16.
+         *        Default is 8.
          */
         public Builder retriesForConnectionFailures(Integer retriesConnectionFailures) {
-            if (retriesConnectionFailures < 1) {
-                throw new IllegalArgumentException("retriesConnectionFailure should be one or more");
+            if (retriesConnectionFailures < 0) {
+                throw new IllegalArgumentException("retriesConnectionFailure should be zero or more");
             }
             client.retriesForConnectionFailures = retriesConnectionFailures;
             return this;
@@ -863,7 +863,7 @@ public class WinRmClient {
     }
 
     private <V> V winrmCallRetryConnFailure(CallableFunction<V> winrmCall) throws SOAPFaultException {
-        int retries = retriesForConnectionFailures != null ? retriesForConnectionFailures : 16;
+        int retries = retriesForConnectionFailures != null ? retriesForConnectionFailures : 8;
         List<Throwable> exceptions = new ArrayList<>();
 
         for (int i = 0; i < retries + 1; i++) {

--- a/winrm4j/src/test/java/io/cloudsoft/winrm4j/winrm/AbstractWinRmToolLiveTest.java
+++ b/winrm4j/src/test/java/io/cloudsoft/winrm4j/winrm/AbstractWinRmToolLiveTest.java
@@ -50,7 +50,7 @@ public class AbstractWinRmToolLiveTest {
     protected static final String VM_USER = System.getProperty("winrm.livetest.user");
     protected static final String VM_PASSWORD = System.getProperty("winrm.livetest.password");
 
-    private WinRmClientContext context;
+    protected WinRmClientContext context;
 
     protected WinRmTool.Builder winRmTool() throws Exception {
 //            return WinRmTool.connect(VM_ADDRESS + ":" + VM_PORT, VM_USER, VM_PASSWORD);

--- a/winrm4j/src/test/java/io/cloudsoft/winrm4j/winrm/AbstractWinRmToolLiveTest.java
+++ b/winrm4j/src/test/java/io/cloudsoft/winrm4j/winrm/AbstractWinRmToolLiveTest.java
@@ -10,6 +10,7 @@ import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -39,7 +40,7 @@ public class AbstractWinRmToolLiveTest {
 
 	private static final Logger LOG = Logger.getLogger(AbstractWinRmToolLiveTest.class.getName());
 
-	protected static final int MAX_EXECUTOR_THREADS = 100;
+	protected static final int MAX_EXECUTOR_THREADS = 50;
 
     protected static final String INVALID_CMD = "thisCommandDoesNotExistAEFafiee3d";
     protected static final String PS_ERR_ACTION_PREF_EQ_STOP = "$ErrorActionPreference = \"Stop\"";
@@ -50,16 +51,18 @@ public class AbstractWinRmToolLiveTest {
     protected static final String VM_USER = System.getProperty("winrm.livetest.user");
     protected static final String VM_PASSWORD = System.getProperty("winrm.livetest.password");
 
+    protected final AtomicInteger winRmToolsCount = new AtomicInteger();
     protected WinRmClientContext context;
 
     protected WinRmTool.Builder winRmTool() throws Exception {
+        LOG.info("Current session counter: " + winRmToolsCount.getAndIncrement());
 //            return WinRmTool.connect(VM_ADDRESS + ":" + VM_PORT, VM_USER, VM_PASSWORD);
         WinRmTool.Builder builder = WinRmTool.Builder.builder(VM_ADDRESS, VM_USER, VM_PASSWORD);
         builder.setAuthenticationScheme(AuthSchemes.NTLM);
         builder.port(VM_PORT);
         builder.useHttps(VM_PORT != 5985);
         builder.disableCertificateChecks(true);
-        builder.context(context);
+        builder.context(WinRmClientContext.newInstance());
         return builder;
     }
 

--- a/winrm4j/src/test/java/io/cloudsoft/winrm4j/winrm/AbstractWinRmToolLiveTest.java
+++ b/winrm4j/src/test/java/io/cloudsoft/winrm4j/winrm/AbstractWinRmToolLiveTest.java
@@ -31,7 +31,7 @@ import io.cloudsoft.winrm4j.client.WinRmClientContext;
 /**
  * Tests execution of commands (batch and powershell) on Windows over WinRM.
  * 
- * See Apache Brooklyn documentation: https://github.com/apache/incubator-brooklyn/blob/master/docs/guide/yaml/winrm/index.md
+ * See Apache Brooklyn documentation: https://github.com/apache/brooklyn-docs/blob/master/guide/blueprints/winrm/index.md
  * Please contact the Apache Brooklyn community (or update their docs) if you encounter  
  * new situations, or change the behaviour of existing use-cases.
  */

--- a/winrm4j/src/test/java/io/cloudsoft/winrm4j/winrm/WinRmChangePassword.java
+++ b/winrm4j/src/test/java/io/cloudsoft/winrm4j/winrm/WinRmChangePassword.java
@@ -2,6 +2,7 @@ package io.cloudsoft.winrm4j.winrm;
 
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;
+import io.cloudsoft.winrm4j.client.WinRmClientContext;
 import org.apache.http.client.config.AuthSchemes;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -24,7 +25,7 @@ public class WinRmChangePassword extends AbstractWinRmToolLiveTest {
         builder.port(VM_PORT);
         builder.useHttps(VM_PORT != 5985);
         builder.disableCertificateChecks(true);
-        builder.context(context);
+        builder.context(WinRmClientContext.newInstance());
         WinRmTool wrongPassTool = builder.build();
         wrongPassTool.setRetriesForConnectionFailures(0);
         try {

--- a/winrm4j/src/test/java/io/cloudsoft/winrm4j/winrm/WinRmChangePassword.java
+++ b/winrm4j/src/test/java/io/cloudsoft/winrm4j/winrm/WinRmChangePassword.java
@@ -1,0 +1,58 @@
+package io.cloudsoft.winrm4j.winrm;
+
+import com.google.common.base.Stopwatch;
+import com.google.common.collect.ImmutableList;
+import org.apache.http.client.config.AuthSchemes;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Random;
+import java.util.logging.Logger;
+
+import static org.testng.Assert.fail;
+
+public class WinRmChangePassword extends AbstractWinRmToolLiveTest {
+    private static final Logger LOG = Logger.getLogger(WinRmChangePassword.class.getName());
+
+    @Test(groups="Live")
+    public void testAuthSuccessAndFail() throws Exception {
+        Stopwatch stopwatchSucceed = Stopwatch.createStarted();
+        assertSucceeded("echo myline", winRmTool().build().executeCommand(ImmutableList.of("echo myline")),"myline","", stopwatchSucceed);
+
+        WinRmTool.Builder builder = WinRmTool.Builder.builder(VM_ADDRESS, VM_USER, "wrOngPass" + new Random().nextInt());
+        builder.setAuthenticationScheme(AuthSchemes.NTLM);
+        builder.port(VM_PORT);
+        builder.useHttps(VM_PORT != 5985);
+        builder.disableCertificateChecks(true);
+        builder.context(context);
+        WinRmTool wrongPassTool = builder.build();
+        wrongPassTool.setRetriesForConnectionFailures(0);
+        try {
+            wrongPassTool.executeCommand(ImmutableList.of("echo myline"));
+            fail("should have failed");
+        } catch (RuntimeException e) {
+            Assert.assertEquals(e.getCause().getMessage(), "Could not send Message.");
+        }
+    }
+
+    @Test(groups="Live")
+    public void testAuthFailAndSuccess() throws Exception {
+        WinRmTool.Builder builder = WinRmTool.Builder.builder(VM_ADDRESS, VM_USER, "wrOngPass" + new Random().nextInt());
+        builder.setAuthenticationScheme(AuthSchemes.NTLM);
+        builder.port(VM_PORT);
+        builder.useHttps(VM_PORT != 5985);
+        builder.disableCertificateChecks(true);
+        builder.context(context);
+        WinRmTool wrongPassTool = builder.build();
+        wrongPassTool.setRetriesForConnectionFailures(0);
+        try {
+            wrongPassTool.executeCommand(ImmutableList.of("echo myline"));
+            fail("should have failed");
+        } catch (RuntimeException e) {
+            Assert.assertEquals(e.getCause().getMessage(), "Could not send Message.");
+        }
+
+        Stopwatch stopwatchSucceed = Stopwatch.createStarted();
+        assertSucceeded("echo myline", winRmTool().build().executeCommand(ImmutableList.of("echo myline")),"myline","", stopwatchSucceed);
+    }
+}

--- a/winrm4j/src/test/java/io/cloudsoft/winrm4j/winrm/WinRmToolExecLiveTest.java
+++ b/winrm4j/src/test/java/io/cloudsoft/winrm4j/winrm/WinRmToolExecLiveTest.java
@@ -436,7 +436,7 @@ public class WinRmToolExecLiveTest extends AbstractWinRmToolLiveTest {
 
     @Test(groups={"Live", "Acceptance"})
     public void testExecConcurrently() throws Exception {
-        final int NUM_RUNS = 10;
+        final int NUM_RUNS = 3;
         final int TIMEOUT_MINS = 30;
         final AtomicInteger counter = new AtomicInteger();
         

--- a/winrm4j/src/test/java/io/cloudsoft/winrm4j/winrm/WinRmToolExecLiveTest.java
+++ b/winrm4j/src/test/java/io/cloudsoft/winrm4j/winrm/WinRmToolExecLiveTest.java
@@ -27,7 +27,7 @@ import com.google.common.util.concurrent.ListenableFuture;
  * There are limitations with what is supported by PyWinRM. These are highlighted in
  * tests marked as "WIP" (see individual tests).
  * 
- * See Apache Brooklyn documentation: https://github.com/apache/incubator-brooklyn/blob/master/docs/guide/yaml/winrm/index.md
+ * See Apache Brooklyn documentation: https://github.com/apache/brooklyn-docs/blob/master/guide/blueprints/winrm/index.md
  * Please contact the Apache Brooklyn community (or update their docs) if you encounter  
  * new situations, or change the behaviour of existing use-cases.
  */


### PR DESCRIPTION
FIrst test doesn't work even in version 0.3.5
`testAuthSuccessAndFail` fails when using NTLM

http://cxf.547215.n5.nabble.com/NTLM-Authentication-being-cached-td5741310.html

BTW I see some commits are made for NTLM changes which might fix the problem https://github.com/apache/httpclient/commits/trunk?after=8a1b96bfa75382c0b94d70f6914fbb9bfeb0451e+69